### PR TITLE
Add a check for a valid SPDX name + other improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ matrix:
   - os: linux
     dist: xenial
     language: python
-    python: '2.7'
-  - os: linux
-    dist: xenial
-    language: python
     python: '3.7'
   - os: osx
     language: generic
@@ -30,7 +26,7 @@ deploy:
     password: ${PYPI_PASSWORD}
     on:
       tags: true
-      condition: "$TRAVIS_PYTHON_VERSION = '2.7'"
+      condition: "$TRAVIS_OS_NAME = 'linux'"
     skip_cleanup: true
     skip_existing: true
   - provider: pypi
@@ -39,6 +35,6 @@ deploy:
     password: ${TEST_PYPI_PASSWORD}
     on:
       branch: master
-      condition: "$TRAVIS_PYTHON_VERSION = '2.7'"
+      condition: "$TRAVIS_OS_NAME = 'linux'"
     skip_cleanup: true
     skip_existing: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ build: false
 
 
 environment:
-    PYTHON: "C:\\Python27"
-    PYTHON_VERSION: "2.7.8"
-    PYTHON_ARCH: "32"
+    PYTHON: "C:\\Python37"
 
     matrix:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
         - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
 install:
-  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
   - pip.exe install -e .[test]
 
 test_script:

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -126,6 +126,10 @@ class Command(object):
 
         :param file: Travis file path
         """
+
+        # Rename .travis -> .ci
+        self._update_travis_path()
+
         compilers = self._read_compiler_versions(file)
         self._logger.debug("Found compilers: {}".format(compilers))
         sorted_compilers = self._add_recommended_compiler_versions(compilers)

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -92,9 +92,9 @@ class Command(object):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--remote', type=str, help='Github repo to be updated e.g. bincrafters/conan-foobar')
         group.add_argument('--local', action='store_true', help='Update current local repository')
-        group.add_argument('-t', '--travisfile', type=str, help='Travis file to be updated e.g. .travis.yml')
-        group.add_argument('-a', '--appveyorfile', type=str, help='Appveyor file to be updated e.g. appveyor.yml')
-        group.add_argument('--conanfile', '-c', type=str, help='Conan recipe path e.g conanfile.py')
+        group.add_argument('-t', '--travisfile', type=str, nargs='?', const='.travis.yml', help='Travis file to be updated e.g. .travis.yml')
+        group.add_argument('-a', '--appveyorfile', type=str, nargs='?', const='appveyor.yml', help='Appveyor file to be updated e.g. appveyor.yml')
+        group.add_argument('--conanfile', '-c', type=str, nargs='?', const='conanfile.py', help='Conan recipe path e.g conanfile.py')
         group.add_argument('--check', action='store_true', help='Checks for additional conventions')
         parser.add_argument('--dry-run', '-d', action='store_true', default=False,
                             help='Do not push after update from remote')

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -95,6 +95,7 @@ class Command(object):
         group.add_argument('-t', '--travisfile', type=str, help='Travis file to be updated e.g. .travis.yml')
         group.add_argument('-a', '--appveyorfile', type=str, help='Appveyor file to be updated e.g. appveyor.yml')
         group.add_argument('--conanfile', '-c', type=str, help='Conan recipe path e.g conanfile.py')
+        group.add_argument('--check', action='store_true', help='Checks for additional conventions')
         parser.add_argument('--dry-run', '-d', action='store_true', default=False,
                             help='Do not push after update from remote')
         parser.add_argument('--project-pattern', '-pp', type=str,
@@ -123,12 +124,15 @@ class Command(object):
                 self._update_remote(arguments.remote, arguments.conanfile, arguments.dry_run, arguments.project_pattern,
                                     arguments.branch_pattern)
             else:
-                if arguments.conanfile:
-                    self._update_conanfile(arguments.conanfile)
-                if arguments.travisfile:
-                    self._update_compiler_jobs(arguments.travisfile)
-                if arguments.appveyorfile:
-                    self._update_appveyor_file(arguments.appveyorfile)
+                if arguments.check:
+                    self._run_conventions_checks()
+                else:
+                    if arguments.conanfile:
+                        self._update_conanfile(arguments.conanfile)
+                    if arguments.travisfile:
+                        self._update_compiler_jobs(arguments.travisfile)
+                    if arguments.appveyorfile:
+                        self._update_appveyor_file(arguments.appveyorfile)
 
     def _update_compiler_jobs(self, file):
         """ Read Travis file and compiler jobs

--- a/bincrafters_conventions/requirements.txt
+++ b/bincrafters_conventions/requirements.txt
@@ -2,3 +2,4 @@ requests==2.20.0
 GitPython==2.1.11
 Jinja2==2.10
 conan>=1.9.0
+spdx-lookup==0.3.2

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
     ],
 


### PR DESCRIPTION
Highlights: When working on a recipe you can just execute `bincrafters-conventions` and old stuff gets updated and additional checks are getting executed and warns you if something isn't right.
Not all good things do require to execute three commends in a row! 😁 

"Additional checks" are checks we can perform to ensure a higher recipe quality, but if the recipe doesn't pass the check there is nothing we can automatically do to improve it.

The first additional check is if the license attribute is a valid SPDX identifier as it should be according to Conan conventions.

Moreover:
  * when updating the travis file (`-t`) the renaming from .travis -> .ci happens now as well
  * adds `--check`  to only run additional checks 
  * provide default names for the options `-t`. `-a` and `-c`