### PR TITLE
Major refactoring of how new compiler jobs are getting added

### DIFF
--- a/bincrafters_conventions/actions/update_other_pyenv_python_version.py
+++ b/bincrafters_conventions/actions/update_other_pyenv_python_version.py
@@ -9,6 +9,9 @@ def update_other_pyenv_python_version(main, file, current_python_version, check_
         old_install_string = "pyenv install {}\n".format(old_version)
         old_virtualenv_string = "pyenv virtualenv {} conan\n".format(old_version)
 
+        if current_install_string == old_install_string and current_virtualenv_string == old_virtualenv_string:
+            continue
+
         if main.file_contains(file, old_install_string):
             if (main.replace_in_file(file, old_install_string, current_install_string) and
                     main.replace_in_file(file, old_virtualenv_string, current_virtualenv_string)):

--- a/bincrafters_conventions/actions/update_other_travis_to_ci_dir_name.py
+++ b/bincrafters_conventions/actions/update_other_travis_to_ci_dir_name.py
@@ -1,4 +1,4 @@
-import shutil
+# import shutil
 import os
 
 
@@ -8,7 +8,8 @@ def update_other_travis_to_ci_dir_name(main):
     travis_dir = ".travis/"
     ci_dir = ".ci/"
     if os.path.isdir(travis_dir):
-        shutil.move(os.path.abspath(travis_dir), os.path.abspath(ci_dir))
+        # shutil.move(os.path.abspath(travis_dir), os.path.abspath(ci_dir))
+        os.rename(os.path.abspath(travis_dir), os.path.abspath(ci_dir))
         main.output_result_update("Update Travis directory path from .travis -> .ci")
         return True
     return False

--- a/bincrafters_conventions/actions/update_other_travis_to_ci_dir_name.py
+++ b/bincrafters_conventions/actions/update_other_travis_to_ci_dir_name.py
@@ -1,4 +1,3 @@
-# import shutil
 import os
 
 
@@ -8,7 +7,6 @@ def update_other_travis_to_ci_dir_name(main):
     travis_dir = ".travis/"
     ci_dir = ".ci/"
     if os.path.isdir(travis_dir):
-        # shutil.move(os.path.abspath(travis_dir), os.path.abspath(ci_dir))
         os.rename(os.path.abspath(travis_dir), os.path.abspath(ci_dir))
         main.output_result_update("Update Travis directory path from .travis -> .ci")
         return True

--- a/bincrafters_conventions/actions/update_t_add_new_compiler_versions.py
+++ b/bincrafters_conventions/actions/update_t_add_new_compiler_versions.py
@@ -1,0 +1,166 @@
+import os
+import re
+
+
+def _get_docker_image_name(compiler: str, version):
+    OWNER = 'conanio'
+
+    version = str(version)
+    image_version = version.replace(".", "")
+    if compiler == "clang" and version == "7.0":
+        image_version = '7'
+
+    return "{}/{}{}".format(OWNER, compiler, image_version)
+
+
+def _create_new_job(compiler: str, version, job: str, old_version, macos_images_mapping: dict):
+    old_version_str = "CONAN_{}_VERSIONS={}".format(compiler.upper(), old_version)
+    new_version_str = "CONAN_{}_VERSIONS={}".format(compiler.upper(), version)
+    job = job.replace(old_version_str, new_version_str)
+
+    if compiler == "gcc" or compiler == "clang":
+        old_docker_image_str = "CONAN_DOCKER_IMAGE={}".format(_get_docker_image_name(compiler, old_version))
+        new_docker_image_str = "CONAN_DOCKER_IMAGE={}".format(_get_docker_image_name(compiler, version))
+        job = job.replace(old_docker_image_str, new_docker_image_str)
+
+    elif compiler == "apple_clang":
+        old_image = macos_images_mapping[old_version]
+        new_image = macos_images_mapping[version]
+        old_image_str = "osx_image: xcode{}".format(old_image)
+        new_image_str = "osx_image: xcode{}".format(new_image)
+        job = job.replace(old_image_str, new_image_str)
+
+    return job
+
+
+def update_t_add_new_compiler_versions(main, file, travis_compiler_versions: dict, macos_images_mapping: dict):
+    """ This update script adds new compiler versions to the Travis jobs
+
+    :param file: Travis file path
+    :param travis_compiler_version: List of recommended new compiler versions
+    :param travis_macos_images_compiler_mapping: Mapping of apple_clang version to specific Travis images
+    """
+
+    beginning_found = -1  # -1, 0 (one of two starting criteria are found) or 1 (both criteria are found), 2 end
+    latest_versions = {'gcc': 0, 'clang': 0, 'apple_clang': 0}
+    versions_jobs = {'gcc': {}, 'clang': {}, 'apple_clang': {}}
+
+    regex_gcc = re.compile(r'CONAN_GCC_VERSIONS=([^\s]+)')
+    regex_clang = re.compile(r'CONAN_CLANG_VERSIONS=([^\s]+)')
+    regex_apple_clang = re.compile(r'CONAN_APPLE_CLANG_VERSIONS=([^\s]+)')
+
+    new_content_beginning = ""
+    compiler_jobs = ""
+    new_content_end = "\n"
+
+    added_new_jobs = False
+    current_compiler = ""
+    current_compiler_version = 0
+
+    tmp = ""
+    compiler_found = False
+
+    if not os.path.isfile(file):
+        return False
+
+    with open(file) as ifd:
+        for line in ifd:
+            # search for the start of the actual jobs
+            if beginning_found != 1:
+
+                # Add this line to the new file
+                if beginning_found == 2:
+                    new_content_end += line
+                else:
+                    new_content_beginning += line
+
+                if line.strip() == "matrix:":
+                    beginning_found = 0
+
+                    continue
+                if line.strip() == "include:" and beginning_found == 0:
+                    beginning_found = 1
+                    continue
+
+                # The include: keywords needs to follow directly the matrix: keyword, if not something is wrong
+                if beginning_found != 2:
+                    beginning_found = -1
+
+            else:
+                # look for end of jobs list
+                if line.strip() == "install:":
+                    # Add this line to the new file
+                    new_content_end += line
+                    beginning_found = 2
+                    continue
+
+                # Skip empty lines
+                if line.strip() is "":
+                    # new_content += line
+                    continue
+
+                # Are we entering a new job?
+                if line.strip()[0] == "-":
+                    current_compiler = ""
+                    current_compiler_version = 0
+                    compiler_found = False
+                    tmp = line
+
+                # What compiler are we currently looking at?
+                if regex_gcc.search(line):
+                    current_compiler = "gcc"
+                    current_compiler_version = regex_gcc.search(line).group(1)
+                    compiler_found = True
+                    versions_jobs[current_compiler]['v'+current_compiler_version] = versions_jobs[current_compiler].get("v"+current_compiler_version, "") + tmp
+                elif regex_clang.search(line):
+                    current_compiler = "clang"
+                    current_compiler_version = regex_clang.search(line).group(1)
+                    compiler_found = True
+                    versions_jobs[current_compiler]['v'+current_compiler_version] = versions_jobs[current_compiler].get("v"+current_compiler_version, "") + tmp
+                elif regex_apple_clang.search(line):
+                    current_compiler = "apple_clang"
+                    current_compiler_version = regex_apple_clang.search(line).group(1)
+                    compiler_found = True
+                    versions_jobs[current_compiler]['v'+current_compiler_version] = versions_jobs[current_compiler].get("v"+current_compiler_version, "") + tmp
+
+                if compiler_found:
+                    versions_jobs[current_compiler]['v'+current_compiler_version] = versions_jobs[current_compiler].get("v"+current_compiler_version, "") + line
+
+                    # Did we found a newer compiler version?
+                    if float(latest_versions[current_compiler]) < float(current_compiler_version):
+                        latest_versions[current_compiler] = current_compiler_version
+
+                elif tmp != line:
+                    tmp += line
+
+    # Add new compiler versions
+    # Loop over recommended new compiler versions
+    for compiler, versions in travis_compiler_versions.items():
+        # Version 0 means that there are no jobs for this compiler existing
+        # So we don't want to add new jobs for this compiler either
+        # Not all packages support all compiler/platforms
+        if latest_versions[compiler] == 0:
+            continue
+
+        for version in versions:
+            # We are only adding compiler versions which are newer than the newest currently already existing
+            # Meaning: If someone is removing older compiler versions we aren't going to re-add them
+            if float(latest_versions[compiler]) < float(version):
+                added_new_jobs = True
+                update_message = "Travis: Add job(s) for new compiler version {} {}".format(compiler, version)
+                main.output_result_update(title=update_message)
+
+                latest_version = latest_versions[compiler]
+                base_job = versions_jobs[compiler]["v"+latest_versions[compiler]]
+                new_job = _create_new_job(compiler, version, base_job, latest_version, macos_images_mapping)
+                versions_jobs[compiler]['v' + version] = new_job
+
+    # Now use the compiler jobs information and transform them back into a writeable string
+    for compiler in ["gcc", "clang", "apple_clang"]:
+        for key in sorted(versions_jobs[compiler].keys(), key=lambda s: float(s[1:])):
+            compiler_jobs += versions_jobs[compiler][key]
+
+    # With all gained information re-write the Travis file now if we actually found missing compiler versions
+    if added_new_jobs:
+        with open(file, 'w') as fd:
+            fd.write(new_content_beginning + compiler_jobs + new_content_end)

--- a/bincrafters_conventions/actions/update_t_add_new_compiler_versions.py
+++ b/bincrafters_conventions/actions/update_t_add_new_compiler_versions.py
@@ -96,7 +96,6 @@ def update_t_add_new_compiler_versions(main, file, travis_compiler_versions: dic
 
                 # Skip empty lines
                 if line.strip() is "":
-                    # new_content += line
                     continue
 
                 # Are we entering a new job?

--- a/bincrafters_conventions/actions/update_t_linux_image.py
+++ b/bincrafters_conventions/actions/update_t_linux_image.py
@@ -7,7 +7,8 @@ def update_t_linux_image(main, file):
     }
 
     for old_image_version, new_image_version in image_update_mapping.items():
-        if main.file_contains(file, old_image_version):
+        if main.file_contains(file, old_image_version) and \
+           not main.file_contains(file, new_image_version):
             if (main.replace_in_file(file, old_image_version, new_image_version)):
                 main.output_result_update(title="Travis: Update Linux CI image from {} to {}".format(old_image_version, new_image_version))
                 return True

--- a/bincrafters_conventions/actions/update_t_linux_image.py
+++ b/bincrafters_conventions/actions/update_t_linux_image.py
@@ -1,0 +1,14 @@
+def update_t_linux_image(main, file):
+    """ Update the Travis Linux base image (i.e. native image, not the images we run via Docker)
+    """
+
+    image_update_mapping = {
+        "sudo: required": "dist: xenial"
+    }
+
+    for old_image_version, new_image_version in image_update_mapping.items():
+        if main.file_contains(file, old_image_version):
+            if (main.replace_in_file(file, old_image_version, new_image_version)):
+                main.output_result_update(title="Travis: Update Linux CI image from {} to {}".format(old_image_version, new_image_version))
+                return True
+    return False

--- a/bincrafters_conventions/actions/update_t_linux_python_version.py
+++ b/bincrafters_conventions/actions/update_t_linux_python_version.py
@@ -1,0 +1,17 @@
+def update_t_linux_python_version(main, file, current_python_version, check_for_old_versions):
+    """ Replaces which Python version is getting installed for Travis Linux CI
+    """
+
+    current_install_string = 'python: "{}"\n'.format(current_python_version)
+
+    for old_version in check_for_old_versions:
+        old_install_string = 'python: "{}"\n'.format(old_version)
+
+        if current_install_string == old_install_string:
+            continue
+
+        if main.file_contains(file, old_install_string):
+            if main.replace_in_file(file, old_install_string, current_install_string):
+                main.output_result_update(title="Update Python version which is installed in Linux Travis CI {}".format(current_install_string))
+                return True
+    return False

--- a/bincrafters_conventions/actions/update_t_macos_images.py
+++ b/bincrafters_conventions/actions/update_t_macos_images.py
@@ -1,0 +1,19 @@
+def update_t_macos_images(main, file, xcode_versions_to_check):
+    """ Sometimes Travis is publishing new CI images with new XCode versions
+        but they still have the same Clang version
+        in this case we do NOT need to add new compiler versions and therefore jobs
+        but we need to update the existing jobs
+    """
+
+    for xcode_update in xcode_versions_to_check:
+        old_image_version = xcode_update[0]
+        new_image_version = xcode_update[1]
+
+        current_image_string = "osx_image: xcode{}\n".format(old_image_version)
+        new_image_string = "osx_image: xcode{}\n".format(new_image_version)
+
+        if main.file_contains(file, current_image_string):
+            if (main.replace_in_file(file, current_image_string, new_image_string)):
+                main.output_result_update(title="Travis: Update macOS CI image from {} to {}".format(old_image_version, new_image_version))
+                return True
+    return False

--- a/bincrafters_conventions/actions/update_t_new_docker_image_names.py
+++ b/bincrafters_conventions/actions/update_t_new_docker_image_names.py
@@ -1,0 +1,28 @@
+def update_t_new_docker_image_names(main, file):
+    """ Updates the names of the docker images from lasote to conanio
+    """
+
+    docker_mappings = {
+        "lasote/conangcc49": "conanio/gcc49",
+        "lasote/conangcc5": "conanio/gcc5",
+        "lasote/conangcc6": "conanio/gcc6",
+        "lasote/conangcc7": "conanio/gcc7",
+        "lasote/conangcc8": "conanio/gcc8",
+        "lasote/conanclang39": "conanio/clang39",
+        "lasote/conanclang40": "conanio/clang40",
+        "lasote/conanclang50": "conanio/clang50",
+        "lasote/conanclang60": "conanio/clang60",
+    }
+
+    found_old_name = False
+
+    for old, new in docker_mappings.items():
+        if main.file_contains(file, old):
+            main.replace_in_file(file, old, new)
+            found_old_name = True
+
+    if found_old_name:
+        main.output_result_update(title="Travis: Update Docker image names from lasote/ to conanio/")
+        return True
+
+    return False

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -30,11 +30,13 @@ from .actions.update_t_ci_dir_path import update_t_ci_dir_path
 from .actions.update_t_macos_images import update_t_macos_images
 from .actions.update_t_new_docker_image_names import update_t_new_docker_image_names
 from .actions.update_t_add_new_compiler_versions import update_t_add_new_compiler_versions
+from .actions.update_t_linux_image import update_t_linux_image
+from .actions.update_t_linux_python_version import update_t_linux_python_version
 from .actions.update_other_travis_to_ci_dir_name import update_other_travis_to_ci_dir_name
 from .actions.update_other_pyenv_python_version import update_other_pyenv_python_version
 
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 
@@ -45,17 +47,19 @@ logging.basicConfig(level=int(LOGGING_LEVEL), format=LOGGING_FORMAT, datefmt='%Y
 # Python version for updating files
 python_version_current_pyenv = "3.7.1"
 python_version_current_appveyor = "37"
+python_version_current_travis_linux = "3.7"
 # for AppVeyor dot zero releases need to be added without dot zero, for pyenv a second time with a dot zero
-python_check_for_old_versions = ["2.7.8", "2.7", "2.7.10", "3.7.0"]
+python_check_for_old_versions = ["2.7.8", "2.7", "2.7.10", "3.6", "3.7.0"]
 
 # Sometimes Travis is publishing new CI images with new XCode versions
 # but they still have the same Clang version
 # in this case we do NOT need to add new compiler versions and therefore jobs
 # but we need to update the existing jobs
-travis_macos_images_updates = [["10.1", "10.2"]]
+# travis_macos_images_updates = [["10.1", "10.2"]] 10.2 isn't ready yet due to zlib problems
+travis_macos_images_updates = []
 
 # What apple_clang version is available on which Travis image?
-travis_macos_images_compiler_mapping = {'7.3': '7.3', '8.1': '8.3', '9.0': '9', '9.1': '9.4', '10.0': '10.2'}
+travis_macos_images_compiler_mapping = {'7.3': '7.3', '8.1': '8.3', '9.0': '9', '9.1': '9.4', '10.0': '10.1'}
 
 # This compiler versions are getting added if they are newer than the existing jobs
 # and if they don't already exist
@@ -151,10 +155,14 @@ class Command(object):
         update_t_ci_dir_path(self, file)
         # Update which Python version macOS is using via pyenv
         update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions)
+        # Update Travis Linux Python version
+        update_t_linux_python_version(self, file, python_version_current_travis_linux, python_check_for_old_versions)
         # Update which macOS image existing jobs are using
         update_t_macos_images(self, file, travis_macos_images_updates)
         # Update docker image names lasote -> conanio
         update_t_new_docker_image_names(self, file)
+        # Update Travis Linux CI base image
+        update_t_linux_image(self, file)
 
         if not self._is_header_only("conanfile.py"):
             # Add new compiler versions to CI jobs

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -156,7 +156,7 @@ class Command(object):
         # Update docker image names lasote -> conanio
         update_t_new_docker_image_names(self, file)
 
-        if not self._is_hearder_only("conanfile.py"):
+        if not self._is_header_only("conanfile.py"):
             # Add new compiler versions to CI jobs
             update_t_add_new_compiler_versions(self, file, travis_compiler_versions, travis_macos_images_compiler_mapping)
 
@@ -200,7 +200,7 @@ class Command(object):
                     return True
         return False
 
-    def _is_hearder_only(self, conanfile):
+    def _is_header_only(self, conanfile):
         """ Check if Conan recipe is header-only
 
         :param conanfile: Conan recipe path
@@ -242,7 +242,7 @@ class Command(object):
         self._logger.info("On branch {}".format(git_repo.active_branch))
 
         try:
-            header_only = self._is_hearder_only(conanfile)
+            header_only = self._is_header_only(conanfile)
             travis_updater = self._update_compiler_jobs
             if header_only:
                 travis_updater = update_t_ci_dir_path(self, conanfile)

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -208,8 +208,6 @@ class Command(object):
         """
         if self.file_contains(conanfile, "self.info.header_only()"):
             return True
-        else:
-            self._logger.warning("Could not check header-only recipe")
         return False
 
     def _get_branch_names(self, git_repo):

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -56,7 +56,7 @@ python_check_for_old_versions = ["2.7.8", "2.7", "2.7.10", "3.6", "3.7.0"]
 # in this case we do NOT need to add new compiler versions and therefore jobs
 # but we need to update the existing jobs
 # travis_macos_images_updates = [["10.1", "10.2"]] 10.2 isn't ready yet due to zlib problems
-travis_macos_images_updates = []
+travis_macos_images_updates = [["9.3", "9.4"]]
 
 # What apple_clang version is available on which Travis image?
 travis_macos_images_compiler_mapping = {'7.3': '7.3', '8.1': '8.3', '9.0': '9', '9.1': '9.4', '10.0': '10.1'}

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -36,7 +36,7 @@ from .actions.update_other_travis_to_ci_dir_name import update_other_travis_to_c
 from .actions.update_other_pyenv_python_version import update_other_pyenv_python_version
 
 
-__version__ = '0.5.2'
+__version__ = '0.5.0'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -29,6 +29,7 @@ from .actions.update_c_default_options_to_dict import update_c_default_options_t
 from .actions.update_c_configure_cmake import update_c_configure_cmake
 from .actions.update_c_source_subfolder import update_c_source_subfolder
 from .actions.update_t_ci_dir_path import update_t_ci_dir_path
+from .actions.update_t_macos_images import update_t_macos_images
 from .actions.update_other_travis_to_ci_dir_name import update_other_travis_to_ci_dir_name
 from .actions.update_other_pyenv_python_version import update_other_pyenv_python_version
 
@@ -46,6 +47,12 @@ python_version_current_pyenv = "3.7.3"
 python_version_current_appveyor = "37"
 # for appveyor dot zero releases need to be added without dot zero, for pyenv a second time with a dot zero
 python_check_for_old_versions = ["2.7.8", "2.7", "2.7.10", "3.7.0", "3.7.1"]
+
+# Sometimes Travis is publishing new CI images with new XCode versions
+# but they still have the same Clang version
+# in this case we do NOT need to add new compiler versions and therefore jobs
+# but we need to update the existing jobs
+travis_macos_images_updates = [["10.1", "10.2"]]
 
 @contextlib.contextmanager
 def chdir(newdir):
@@ -179,8 +186,12 @@ class Command(object):
 
         # Rename .travis -> .ci
         update_other_travis_to_ci_dir_name(self)
+        # Update which Python version macOS is using via pyenv
         update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions)
+        # Update which macOS image existing jobs are using
+        update_t_macos_images(self, file, travis_macos_images_updates)
 
+        # Update compiler jobs
         compilers = self._read_compiler_versions(file)
         self._logger.debug("Found compilers: {}".format(compilers))
         sorted_compilers = self._add_recommended_compiler_versions(compilers)
@@ -217,7 +228,7 @@ class Command(object):
         has_linux = False
         has_osx = False
         compiler_list = []
-        osx_versions = {'7.3': '7.3', '8.1': '8.3', '9.0': '9', '9.1': '9.4', '10.0': '10.1'}
+        osx_versions = {'7.3': '7.3', '8.1': '8.3', '9.0': '9', '9.1': '9.4', '10.0': '10.2'}
         total_pages = self._get_compiler_pages(file)
 
         for compiler_name in ['gcc', 'clang']:

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -9,8 +9,6 @@ import git
 import tempfile
 import requests
 import contextlib
-import collections
-import jinja2
 import re
 from .actions.check_for_spdx_license import check_for_spdx_license
 from .actions.check_for_download_hash import check_for_download_hash

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -30,12 +30,13 @@ from .actions.update_c_configure_cmake import update_c_configure_cmake
 from .actions.update_c_source_subfolder import update_c_source_subfolder
 from .actions.update_t_ci_dir_path import update_t_ci_dir_path
 from .actions.update_t_macos_images import update_t_macos_images
+from .actions.update_t_new_docker_image_names import update_t_new_docker_image_names
 from .actions.update_t_add_new_compiler_versions import update_t_add_new_compiler_versions
 from .actions.update_other_travis_to_ci_dir_name import update_other_travis_to_ci_dir_name
 from .actions.update_other_pyenv_python_version import update_other_pyenv_python_version
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 
@@ -153,6 +154,8 @@ class Command(object):
         update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions)
         # Update which macOS image existing jobs are using
         update_t_macos_images(self, file, travis_macos_images_updates)
+        # Update docker image names lasote -> conanio
+        update_t_new_docker_image_names(self, file)
 
         # Add new compiler versions to CI jobs
         update_t_add_new_compiler_versions(self, file, travis_compiler_versions, travis_macos_images_compiler_mapping)

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -256,9 +256,6 @@ class Command(object):
             else:
                 self._logger.info("Conan recipe is not for header-only project")
 
-            # versions = self._read_compiler_versions(file)
-            # self._logger.info(versions)
-
             result = (update_other_travis_to_ci_dir_name(self),
                       update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions),
                       self._update_conanfile(conanfile),

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -148,6 +148,7 @@ class Command(object):
 
         # Rename .travis -> .ci
         update_other_travis_to_ci_dir_name(self)
+        update_t_ci_dir_path(self, file)
         # Update which Python version macOS is using via pyenv
         update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions)
         # Update which macOS image existing jobs are using
@@ -155,8 +156,9 @@ class Command(object):
         # Update docker image names lasote -> conanio
         update_t_new_docker_image_names(self, file)
 
-        # Add new compiler versions to CI jobs
-        update_t_add_new_compiler_versions(self, file, travis_compiler_versions, travis_macos_images_compiler_mapping)
+        if not self._is_hearder_only("conanfile.py"):
+            # Add new compiler versions to CI jobs
+            update_t_add_new_compiler_versions(self, file, travis_compiler_versions, travis_macos_images_compiler_mapping)
 
     def _update_appveyor_file(self, file):
         update_a_python_environment_variable(self, file)

--- a/bincrafters_conventions/requirements.txt
+++ b/bincrafters_conventions/requirements.txt
@@ -1,5 +1,4 @@
 requests==2.21.0
 GitPython==2.1.11
-Jinja2==2.10
 conan>=1.9.0
 spdx-lookup==0.3.2


### PR DESCRIPTION
When adding new jobs for new compiler versions to the Travis file it supports now arbitrary environment variables, keywords (except "install"), number of jobs per compiler version etc.

It uses this information and re-uses it to add new jobs for newer compiler versions

It also supports arbitrary file beginning/endings and allows therefore customizations on a per-project base while still being compatible with this script.

With the current version of bincrafters-conventions the script is simply overwriting custom environment variables / Conan variables etc. The only thing it respected beside `CONAN_XYZ_VERSIONS` and `CONAN_DOCKER_IMAGE` was `CONAN_TOTAL_PAGES` and `CONAN_CURRENT_PAGE`

All-in-all it should be much more stable and useful, however, since it is adding incremental new CI jobs instead of re-generating the entire file, a few more update scripts are required now