### PR TITLE
Major improvement in remote feature

### DIFF
--- a/bincrafters_conventions/actions/update_t_linux_python_version.py
+++ b/bincrafters_conventions/actions/update_t_linux_python_version.py
@@ -12,6 +12,6 @@ def update_t_linux_python_version(main, file, current_python_version, check_for_
 
         if main.file_contains(file, old_install_string):
             if main.replace_in_file(file, old_install_string, current_install_string):
-                main.output_result_update(title="Update Python version which is installed in Linux Travis CI {}".format(current_install_string))
+                main.output_result_update(title="Update Python version which is installed in Linux Travis CI to {}".format(current_python_version))
                 return True
     return False

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -178,10 +178,6 @@ class Command(object):
         """
         result = []
 
-        if not self._is_header_only("conanfile.py"):
-            result.extend([update_t_jobs(self, file, compiler_versions, travis_macos_images_compiler_mapping,
-                          compiler_versions_deletion)])
-
         result.extend([
             # Rename .travis -> .ci
             update_other_travis_to_ci_dir_name(self),
@@ -198,6 +194,10 @@ class Command(object):
             # Update Travis Linux CI base image
             update_t_linux_image(self, file),
         ])
+
+        if not self._is_header_only("conanfile.py"):
+            result.extend([update_t_jobs(self, file, compiler_versions, travis_macos_images_compiler_mapping,
+                          compiler_versions_deletion)])
 
         return result
 
@@ -459,7 +459,8 @@ class Command(object):
                 branches.extend(self._get_branch_names(git_repo))
             else:
                 self.output_remote_update("Update default branch only")
-                branches.extend([git_repo.head.ref])
+                default_branch = str(git_repo.head.ref)
+                branches.extend([default_branch])
             if branch_pattern:
                 branches = self._filter_list(branches, branch_pattern)
             for branch in branches:

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -38,7 +38,7 @@ from .actions.update_other_pyenv_python_version import update_other_pyenv_python
 from .actions.update_readme_travis_url import update_readme_travis_url
 
 
-__version__ = '0.7.10'
+__version__ = '0.8.0'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -270,23 +270,17 @@ class Command(object):
         :param skip_push: Do not push
         """
         git_repo.git.checkout(branch)
-        self._logger.info("On branch {}".format(git_repo.active_branch))
+
+        print("\n")
+        self._logger.info("\033[1;32mOn branch {}\033[0m".format(git_repo.active_branch))
 
         try:
             conanfile = "conanfile.py" if conanfile is None else conanfile
-            header_only = self._is_header_only(conanfile)
-            travis_updater = self._update_compiler_jobs
-            if header_only:
-                travis_updater = update_t_ci_dir_path(self, conanfile)
-                self._logger.info("Conan recipe for header-only project")
-            else:
-                self._logger.info("Conan recipe is not for header-only project")
-
-            result = (update_other_travis_to_ci_dir_name(self),
-                      update_other_pyenv_python_version(self, '.ci/install.sh', python_version_current_pyenv, python_check_for_old_versions),
-                      self._update_conanfile(conanfile),
-                      travis_updater(file),
-                      self._update_appveyor_file('appveyor.yml'))
+            result = (self._update_conanfile(conanfile),
+                      self._update_readme('README.md'),
+                      self._update_compiler_jobs('.travis.yml'),
+                      self._update_appveyor_file('appveyor.yml')
+            )
             if True in result:
                 self._logger.debug("Add file {} on branch {}".format(file, git_repo.active_branch))
                 git_repo.git.add('--all')

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -392,17 +392,22 @@ class Command(object):
         return repo, project_path
 
     def _list_user_projects(self, user):
-        """ List all projects from Github public account
+        """ List all projects from GitHub public account
 
         :param user: User name
         """
         projects = []
-        repos_url = 'https://api.github.com/users/{}/repos'.format(user)
-        response = requests.get(repos_url)
-        if not response.ok:
-            raise Exception("Could not retrieve {}".format(repos_url))
-        for project in response.json():
-            projects.append(project["full_name"])
+        pages = (1, 2)
+        for page in pages:
+            repos_url = 'https://api.github.com/users/{}}/repos?sort=updated&direction=asc&per_page=100&page={}'\
+                .format(user, page)
+            response = requests.get(repos_url)
+            if page == 1 and not response.ok:
+                raise Exception("Could not retrieve {}".format(repos_url))
+            for project in response.json():
+                if not project["archived"] and not project["fork"] and not project["disabled"]:
+                    projects.append(project["full_name"])
+        self._logger.info(" ".join(map(str, projects)))
         return projects
 
     def _filter_list(self, names, pattern):


### PR DESCRIPTION
  * `--remote` actually applies now all convention updates
  * only the default git branch is getting updated per default now; `--all-branches` arg introduced for updating ALL branches within a repository (which is undesired in most cases)
  * improve commit message to save CI time, by adding dynamically `[skip travis]` or `[skip appveyor]` if possible
  * allow to authenticate with GitHub token in the format `username:token` with the new parameter `--remote-token`
  * if remote update of the entire organisation  (instead of a single repository) is executed
    * this has now a new default `--remote-max-repos` value of 3 (you seriously don't want to update accidentally several hundred repositories)
    * theoretically up to 200 repositories max can be updated in one rush (more would be possible, but this is probably not a good idea to prevent accidents)
      * this 200 repositories are getting fetched via GitHub's API
       * repositories which didn't get touched in a while are preferred for updates
       * repository name has to start with `conan-`
       * repository name isn't allow to start with `conan-boost`
       * repositories who are up to date with our current conventions do not count towards the `--remote-max-repos` amount; only actual updates do count