### PR TITLE
Remove existing Apple Clang 7.3 CI jobs

### DIFF
--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -39,7 +39,7 @@ from .actions.update_other_pyenv_python_version import update_other_pyenv_python
 from .actions.update_readme_travis_url import update_readme_travis_url
 
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 
@@ -71,7 +71,7 @@ compiler_versions = {'gcc': ('6', '7', '8', '9'),
                      'apple_clang': ('9.1', '10.0'),  # TODO: Add '11.0' when stable
                      'visual': ('15', '16')}
 # This compiler versions are getting actively removed from existing jobs
-compiler_versions_deletion = {'gcc': (), 'clang': (), 'apple_clang': (), 'visual': ()}
+compiler_versions_deletion = {'gcc': (), 'clang': (), 'apple_clang': ('7.3',), 'visual': ()}
 
 
 # What are the latest AVAILABLE patches for OpenSSL, which versions are End-Of-Life?

--- a/tests/files/travis_1_expected.yml
+++ b/tests/files/travis_1_expected.yml
@@ -35,9 +35,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3
-      - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - <<: *osx

--- a/tests/files/travis_with_globals_expected.yml
+++ b/tests/files/travis_with_globals_expected.yml
@@ -63,12 +63,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8 CONAN_CURRENT_PAGE=2
       - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=1
-      - <<: *osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3 CONAN_CURRENT_PAGE=2
-      - <<: *osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1 CONAN_CURRENT_PAGE=1
       - <<: *osx


### PR DESCRIPTION
Reasoning:
  * we started to not add Apple Clang 7.3 jobs to new recipes 5 months ago: https://github.com/bincrafters/templates/pull/50
  * the stack was already end-of-life back then and certainly is now
  * Apple Clang 7.3 jobs are increasingly failing in our CI
  * it is expected that Apple Clang 11 / XCode 11 / macOS 10.15 is released somewhen around 23. Sep
    * meaning that in a month from now we do have jobs for Apple Clang 8.1 / 9.0 / 9.1 / 10.0 / 11.0, running on macOS 10.12 - 10.15
    * that should be enough coverage

