### PR TITLE
CCI adaptions + better installer support + new OpenSSL patches

### DIFF
--- a/bincrafters_conventions/actions/update_c_openssl_version_patch.py
+++ b/bincrafters_conventions/actions/update_c_openssl_version_patch.py
@@ -21,8 +21,6 @@ def update_c_openssl_version_patch(main, file, openssl_version_matrix: dict):
 
     for line in ccontent:
         for key, version_matrix in openssl_version_matrix.items():
-            # TODO: After OpenSSL 3 release we need to handle the rename of the recipe to lower-case
-            #  + change of version schema
             regex_patches = [
                 re.compile('OpenSSL/{}'.format(key) + r'([^\s]+)@conan/stable'),
                 re.compile('openssl/{}'.format(key) + r'([^\s]+)(\'|\")')

--- a/bincrafters_conventions/actions/update_c_recipe_references.py
+++ b/bincrafters_conventions/actions/update_c_recipe_references.py
@@ -1,0 +1,73 @@
+import os
+
+
+def update_c_recipe_references(main, file):
+    """ This update script updates Conan references, mostly
+
+    :param file: Conan file path
+    """
+
+    if not os.path.isfile(file):
+        return False
+
+    references_updated = False
+
+    references = {
+        "zlib/1.2.8@conan/stable": "zlib/1.2.11",
+        "zlib/1.2.9@conan/stable": "zlib/1.2.11",
+        "zlib/1.2.11@conan/stable": "zlib/1.2.11",
+
+        "zstd/1.3.8@bincrafters/stable": "zstd/1.3.8",
+        "zstd/1.4.0@bincrafters/stable": "zstd/1.4.3",
+
+        "strawberryperl/5.28.1.1@conan/stable": "strawberryperl/5.28.1.1",
+        "strawberryperl/5.30.0.1@conan/stable": "strawberryperl/5.30.0.1",
+
+        "sqlite3/3.29.0@bincrafters/stable": "sqlite3/3.29.0",
+
+        "Poco/1.8.1@pocoproject/stable": "poco/1.8.1",
+        "Poco/1.9.3@pocoproject/stable": "poco/1.9.3",
+
+        "OpenSSL/1.0.2s@conan/stable": "openssl/1.0.2t",
+        "OpenSSL/1.0.2t@conan/stable": "openssl/1.0.2t",
+        "OpenSSL/1.1.0k@conan/stable": "openssl/1.1.0l",
+        "OpenSSL/1.1.0l@conan/stable": "openssl/1.1.0l",
+        "OpenSSL/1.1.1c@conan/stable": "openssl/1.1.1d",
+        "OpenSSL/1.1.1d@conan/stable": "openssl/1.1.1d",
+
+        "nasm/2.13.01@conan/stable": "nasm/2.13.02",
+        "nasm_installer/2.13.02@bincrafters/stable": "nasm/2.13.02",
+
+        "msys2_installer/20161025@bincrafters/stable": "msys2/20161025",
+
+        "libjpeg/9b@bincrafters/stable": "libjpeg/9c",
+        "libjpeg/9c@bincrafters/stable": "libjpeg/9c",
+
+        "fmt/5.3.0@bincrafters/stable": "fmt/5.3.0",
+
+        "Expat/2.2.1@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.2@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.3@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.4@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.5@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.6@pix4d/stable": "expat/2.2.7",
+        "Expat/2.2.7@pix4d/stable": "expat/2.2.7",
+
+        "bzip2/1.0.6@conan/stable": "bzip2/1.0.6",
+        "bzip2/1.0.8@conan/stable": "bzip2/1.0.8",
+
+        "boost/1.70.0@conan/stable": "boost/1.70.0",
+        "boost/1.71.0@conan/stable": "boost/1.71.0",
+    }
+
+    for old_ref, new_ref in references.items():
+        if main.replace_in_file(file, old_ref, new_ref):
+            msg = "Update Conan recipe reference from {} to {}".format(old_ref, new_ref)
+            main.output_result_update(title=msg)
+            references_updated = True
+
+    if references_updated:
+        return True
+
+    return False
+

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -77,9 +77,9 @@ compiler_versions_deletion = {'gcc': (), 'clang': (), 'apple_clang': ('7.3',), '
 
 # What are the latest AVAILABLE patches for OpenSSL, which versions are End-Of-Life?
 openssl_version_matrix = {'1.0.1': {'latest_patch': 'h', 'eol': True},
-                          '1.0.2': {'latest_patch': 's', 'eol': False},
-                          '1.1.0': {'latest_patch': 'k', 'eol': False},
-                          '1.1.1': {'latest_patch': 'c', 'eol': False},
+                          '1.0.2': {'latest_patch': 't', 'eol': False},
+                          '1.1.0': {'latest_patch': 'l', 'eol': True},
+                          '1.1.1': {'latest_patch': 'd', 'eol': False},
                           }
 
 @contextlib.contextmanager

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -29,6 +29,7 @@ from .actions.update_c_openssl_version_patch import update_c_openssl_version_pat
 from .actions.update_c_generic_exception_to_invalid_conf import update_c_generic_exception_to_invalid_conf
 from .actions.update_c_default_options_to_dict import update_c_default_options_to_dict
 from .actions.update_c_tools_version import update_c_tools_version
+from .actions.update_c_recipe_references import update_c_recipe_references
 from .actions.update_t_ci_dir_path import update_t_ci_dir_path
 from .actions.update_t_macos_images import update_t_macos_images
 from .actions.update_t_new_docker_image_names import update_t_new_docker_image_names
@@ -370,7 +371,10 @@ class Command(object):
                 update_c_generic_exception_to_invalid_conf(self, conanfile),
                 update_c_openssl_version_patch(self, conanfile, openssl_version_matrix),
                 update_c_tools_version(self, conanfile),
-                update_c_author(self, conanfile), update_c_topics(self, conanfile)]
+                update_c_author(self, conanfile),
+                update_c_topics(self, conanfile),
+                update_c_recipe_references(self, conanfile)
+                ]
 
     def _update_readme(self, readme):
         """ Update README.md file with new URL

--- a/tests/files/conan_1_expected.py
+++ b/tests/files/conan_1_expected.py
@@ -24,7 +24,6 @@ class DoubleConversionConan(ConanFile):
     _source_subfolder = "source_subfolder"
     _build_subfolder = "build_subfolder"
 
-
     def config_options(self):
         if self.settings.os == "Windows":
             self.options.remove("fPIC")

--- a/tests/files/conan_1_old.py
+++ b/tests/files/conan_1_old.py
@@ -23,7 +23,6 @@ class DoubleConversionConan(ConanFile):
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
 
-
     def config_options(self):
         if self.settings.os == "Windows":
             self.options.remove("fPIC")

--- a/tests/files/conan_2_expected.py
+++ b/tests/files/conan_2_expected.py
@@ -1,0 +1,92 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class GrpcConan(ConanFile):
+    name = "grpc"
+    version = "1.23.0"
+    description = "Google's RPC library and framework."
+    topics = ("conan", "grpc", "rpc")
+    url = "https://github.com/bincrafters/conan-grpc"
+    homepage = "https://github.com/grpc/grpc"
+    author = "Bincrafters <bincrafters@gmail.com>"
+    license = "Apache-2.0"
+    exports = ["LICENSE.md"]
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "build_codegen": [True, False],
+        "build_csharp_ext": [True, False]
+    }
+    default_options = {
+        "fPIC": True,
+        "build_codegen": True,
+        "build_csharp_ext": False
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    requires = (
+        "zlib/1.2.11",
+        "openssl/1.0.2t",
+        "protobuf/3.9.1@bincrafters/stable",
+        "c-ares/1.15.0@conan/stable"
+    )
+
+    def configure(self):
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+            compiler_version = int(str(self.settings.compiler.version))
+            if compiler_version < 14:
+                raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+    def source(self):
+        sha256 = "86d7552cb79ab9ba7243d86b768952df1907bacb828f5f53b8a740f716f3937b"
+        tools.get("{}/archive/v{}.zip".format(self.homepage, self.version), sha256=sha256)
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+        cmake_path = os.path.join(self._source_subfolder, "CMakeLists.txt")
+
+        tools.replace_in_file(cmake_path, "_gRPC_PROTOBUF_LIBRARIES", "CONAN_LIBS_PROTOBUF")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy('*', dst='include', src='{}/include'.format(self._source_subfolder))
+        self.copy('*.cmake', dst='lib', src='{}/lib'.format(self._build_subfolder), keep_path=True)
+        self.copy("*.lib", dst="lib", src="", keep_path=False)
+        self.copy("*.a", dst="lib", src="", keep_path=False)
+        self.copy("*", dst="bin", src="bin")
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        self.cpp_info.libs = [
+            "grpc++",
+            "grpc",
+            "grpc++_unsecure",
+            "grpc_unsecure",
+            "gpr",
+            "address_sorting"
+        ]
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.libs += ["wsock32", "ws2_32"]

--- a/tests/files/conan_2_old.py
+++ b/tests/files/conan_2_old.py
@@ -1,0 +1,92 @@
+from conans import ConanFile, CMake, tools
+from conans.errors import ConanInvalidConfiguration
+import os
+
+
+class GrpcConan(ConanFile):
+    name = "grpc"
+    version = "1.23.0"
+    description = "Google's RPC library and framework."
+    topics = ("conan", "grpc", "rpc")
+    url = "https://github.com/bincrafters/conan-grpc"
+    homepage = "https://github.com/grpc/grpc"
+    author = "Bincrafters <bincrafters@gmail.com>"
+    license = "Apache-2.0"
+    exports = ["LICENSE.md"]
+    exports_sources = ["CMakeLists.txt"]
+    generators = "cmake"
+    short_paths = True  # Otherwise some folders go out of the 260 chars path length scope rapidly (on windows)
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {
+        "fPIC": [True, False],
+        "build_codegen": [True, False],
+        "build_csharp_ext": [True, False]
+    }
+    default_options = {
+        "fPIC": True,
+        "build_codegen": True,
+        "build_csharp_ext": False
+    }
+
+    _source_subfolder = "source_subfolder"
+    _build_subfolder = "build_subfolder"
+
+    requires = (
+        "zlib/1.2.11@conan/stable",
+        "OpenSSL/1.0.2r@conan/stable",
+        "protobuf/3.9.1@bincrafters/stable",
+        "c-ares/1.15.0@conan/stable"
+    )
+
+    def configure(self):
+        if self.settings.os == "Windows" and self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+            compiler_version = int(str(self.settings.compiler.version))
+            if compiler_version < 14:
+                raise ConanInvalidConfiguration("gRPC can only be built with Visual Studio 2015 or higher.")
+
+    def source(self):
+        sha256 = "86d7552cb79ab9ba7243d86b768952df1907bacb828f5f53b8a740f716f3937b"
+        tools.get("{}/archive/v{}.zip".format(self.homepage, self.version), sha256=sha256)
+        extracted_dir = self.name + "-" + self.version
+        os.rename(extracted_dir, self._source_subfolder)
+
+        cmake_path = os.path.join(self._source_subfolder, "CMakeLists.txt")
+
+        tools.replace_in_file(cmake_path, "_gRPC_PROTOBUF_LIBRARIES", "CONAN_LIBS_PROTOBUF")
+
+    def _configure_cmake(self):
+        cmake = CMake(self)
+        cmake.configure(build_folder=self._build_subfolder)
+        return cmake
+
+    def build(self):
+        cmake = self._configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self._configure_cmake()
+        cmake.install()
+
+        self.copy(pattern="LICENSE", dst="licenses")
+        self.copy('*', dst='include', src='{}/include'.format(self._source_subfolder))
+        self.copy('*.cmake', dst='lib', src='{}/lib'.format(self._build_subfolder), keep_path=True)
+        self.copy("*.lib", dst="lib", src="", keep_path=False)
+        self.copy("*.a", dst="lib", src="", keep_path=False)
+        self.copy("*", dst="bin", src="bin")
+        self.copy("*.dll", dst="bin", keep_path=False)
+        self.copy("*.so", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
+        self.cpp_info.libs = [
+            "grpc++",
+            "grpc",
+            "grpc++_unsecure",
+            "grpc_unsecure",
+            "gpr",
+            "address_sorting"
+        ]
+        if self.settings.compiler == "Visual Studio":
+            self.cpp_info.libs += ["wsock32", "ws2_32"]

--- a/tests/files/conan_multiline_options_old.py
+++ b/tests/files/conan_multiline_options_old.py
@@ -24,7 +24,6 @@ class DoubleConversionConan(ConanFile):
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
 
-
     def config_options(self):
         if self.settings.os == "Windows":
             self.options.remove("fPIC")

--- a/tests/test_update_file.py
+++ b/tests/test_update_file.py
@@ -76,6 +76,19 @@ def test_conanfile_default_options_mutiline():
     assert _compare_file(path_old, path_expected)
 
 
+def test_conanfile_2():
+    """ Try to update an conanfile which old Conan recipe references
+    """
+
+    path_old, path_expected = _prepare_old_file("conan_2", ".py")
+
+    args = ['--conanfile', path_old]
+    command = Command()
+    command.run(args)
+
+    assert _compare_file(path_old, path_expected)
+
+
 def test_appveyor_update_up_to_date():
     """ Try to update an up-to-date AppVeyor file
     """


### PR DESCRIPTION
  * updates OpenSSL versions to the latest patches
  * OpenSSL 1.1.0 is now end-of-life; show failure when this versions gets used and checks are run
  * update dependency references to versions from CCI, I will keep this list updated when more are adopted into CCI 
  * fixed: `*_installer` packages don't get new CI jobs added anymore