### PR TITLE
disable libmout/2.36 upgrade

### DIFF
--- a/bincrafters_conventions/actions/update_c_recipe_references.py
+++ b/bincrafters_conventions/actions/update_c_recipe_references.py
@@ -262,8 +262,10 @@ REFERENCES = {
     "lcms/2.9@bincrafters/stable": "lcms/2.9",
 
     "libmount/2.33.1@bincrafters/stable": "libmount/2.33.1",
-    "libmount/2.33.1": "libmount/2.36",
-    "libmount/2.36": "libmount/2.36.2",
+    "libmount/2.33.1": "libmount/2.36.2",
+    # this is a problem because libmount/2.36.2 gets migrated
+    # into libmount/2.36.2.2, etc.
+    # "libmount/2.36": "libmount/2.36.2",
 
     "libxml2/2.9.3@bincrafters/stable": "libxml2/2.9.9",
     "libxml2/2.9.8@bincrafters/stable": "libxml2/2.9.9",


### PR DESCRIPTION
@Croydon Disabling this is not the solution, do you have an idea how we could keep the upgrade from `libmount/2.36` to `libmount/2.36.2`, without having `libmount/2.36.2` migrated to `libmount/2.36.2.2` ?