### PR TITLE
v1.0

### DIFF
--- a/.github/workflows/clone_recipes_to_artifactory.yml.disable
+++ b/.github/workflows/clone_recipes_to_artifactory.yml.disable
@@ -7,7 +7,7 @@ jobs:
     name: "Clone Recipes To Artifactory"
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.8"
     - name: "Install Conan"

--- a/README.md
+++ b/README.md
@@ -9,21 +9,24 @@
 This project contains scripts to update CI files, to
 update Conan conventions in general and to perform some linting.
 
-#### INSTALL
-To install by pip is just one step
+### INSTALL
 
-##### Local
-If you want to install via a local git clone
+You can install `bincrafters-conventions` via `pip` like this:
 
-    pip install .
+    $ pip install bincrafters_conventions
 
-##### Remote
-Or if you want to install a release version
+### RUN
 
-    pip install bincrafters_conventions
+> 💡 Bincrafters Conventions is a command line tool.
+> 
+> Execute `bincrafters-conventions --help` to see all options.
+> 
+> `bincrafters-conventions` has also the alias `bcon` for convince.
 
-#### RUN
-To update **ALL** Conan projects on GitHub https://github.com/bincrafters
+
+#### EXAMPLES
+
+To update **ALL** Conan projects on GitHub for https://github.com/bincrafters
 
     $ bincrafters_conventions --remote=bincrafters
 
@@ -64,25 +67,22 @@ To update AppVeyor file:
     $ bincrafters_conventions --appveryorfile=appveyor.yml
 
 
-##### Testing and Development
+### Testing and Development
+
+If you want to install `bincrafters-conventions` via a local git clone
+
+    pip install --user -U .
+
 To install extra packages required to test
 
     pip install .[test]
 
-
-#### TESTING
 To run all unit test + code coverage, execute:
 
-    pip install .[test]
     cd tests
     pytest -v --cov=bincrafters_conventions
 
 
-#### REQUIREMENTS and DEVELOPMENT
-To develop or run bincrafters-conventions:
+### LICENSE
 
-    pip install --user -U .
-    bincrafters-conventions
-
-#### LICENSE
 [MIT](LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -54,10 +54,6 @@ To update and check **LOCAL** everything
 To check **LOCAL** everything
 
     $ bincrafters_conventions --check
-    
-To update a **LOCAL** file
-
-    $ bincrafters_conventions --travisfile=.travis.yml
 
 To apply Conan conventions in a local file:
 

--- a/bincrafters_conventions/actions/update_c_recipe_references.py
+++ b/bincrafters_conventions/actions/update_c_recipe_references.py
@@ -14,6 +14,7 @@ REFERENCES = {
     "zlib/1.2.9@conan/stable": "zlib/1.2.11",
     "zlib/1.2.11@conan/stable": "zlib/1.2.11",
     "zlib/1.2.11": "zlib/1.2.12",
+    "zlib/1.2.12": "zlib/1.2.13",
 
     "zstd/1.3.5@bincrafters/stable": "zstd/1.3.5",
     "zstd/1.3.8@bincrafters/stable": "zstd/1.3.8",

--- a/bincrafters_conventions/actions/update_c_recipe_references.py
+++ b/bincrafters_conventions/actions/update_c_recipe_references.py
@@ -13,6 +13,7 @@ REFERENCES = {
     "zlib/1.2.8@conan/stable": "zlib/1.2.11",
     "zlib/1.2.9@conan/stable": "zlib/1.2.11",
     "zlib/1.2.11@conan/stable": "zlib/1.2.11",
+    "zlib/1.2.11": "zlib/1.2.12",
 
     "zstd/1.3.5@bincrafters/stable": "zstd/1.3.5",
     "zstd/1.3.8@bincrafters/stable": "zstd/1.3.8",

--- a/bincrafters_conventions/actions/update_gha.yml
+++ b/bincrafters_conventions/actions/update_gha.yml
@@ -1,4 +1,4 @@
-# bincrafters-conventions:gha-workflow-version:13
+# bincrafters-conventions:gha-workflow-version:14
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install Package Tools
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install Conan

--- a/bincrafters_conventions/actions/update_gha.yml
+++ b/bincrafters_conventions/actions/update_gha.yml
@@ -1,11 +1,11 @@
-# bincrafters-conventions:gha-workflow-version:10
+# bincrafters-conventions:gha-workflow-version:13
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
 #
 # Possible configurations:
 # env:
-#   splitByBuildTypes: "false"  # Possible values "false", "true", default: false
+#   BPT_MATRIX_SPLIT_BY_BUILD_TYPES: "false"  # Possible values "false", "true", default: false
 #
 # You can furthermore set any environment variable understood by Conan and Conan Package Tools
 #
@@ -20,11 +20,13 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      BPT_CONFIG_FILE_VERSION: "12"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
       - name: Install Package Tools
@@ -33,8 +35,6 @@ jobs:
           conan user
       - name: Generate Job Matrix
         id: set-matrix
-        env:
-          splitByBuildTypes: ${{ env.splitByBuildTypes }}
         run: |
           MATRIX=$(bincrafters-package-tools generate-ci-jobs --platform gha)
           echo "${MATRIX}"
@@ -46,11 +46,13 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
     name: ${{ matrix.config.name }}
+    env:
+      BPT_CONFIG_FILE_VERSION: "12"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
       - name: Install Conan
@@ -68,3 +70,11 @@ jobs:
           CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
         run: |
           bincrafters-package-tools --auto
+  finished:
+    needs: conan
+    runs-on: ubuntu-20.04
+    name: "All GitHub Actions Jobs Finished"
+    steps:
+      - name: Finish
+        run: |
+          echo "All GitHub Actions jobs finished"

--- a/bincrafters_conventions/actions/update_gha.yml
+++ b/bincrafters_conventions/actions/update_gha.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           MATRIX=$(bincrafters-package-tools generate-ci-jobs --platform gha)
           echo "${MATRIX}"
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
   conan:
     needs: generate-matrix
     runs-on: ${{ matrix.config.os }}

--- a/bincrafters_conventions/actions/update_readme_travis_url.py
+++ b/bincrafters_conventions/actions/update_readme_travis_url.py
@@ -1,7 +1,0 @@
-def update_readme_travis_url(main, file):
-    """ Update Travis CI URL
-    """
-    if main.replace_in_file(file, "https://travis-ci.org/bincrafters", "https://travis-ci.com/bincrafters"):
-        main.output_result_update(title="README: Update Travis URL from .org to .com")
-        return True
-    return False

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -122,7 +122,7 @@ class Command(object):
         :param args: User arguments
         """
         arguments = self._parse_arguments(*args)
-        if not len(sys.argv) > 1 or arguments.local:
+        if not len(*args) > 1 or arguments.local:
             self._update_compiler_jobs(".travis.yml")
             self._update_appveyor_file("appveyor.yml")
             self._update_azp_file("azure-pipelines.yml")

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -188,7 +188,7 @@ class Command(object):
         if not os.path.isfile(file):
             return [False, ]
 
-        result = [ ]
+        result = []
 
         return result
 
@@ -353,7 +353,7 @@ class Command(object):
         if not os.path.isfile(readme):
             return [False, ]
 
-        return [True, ]
+        return []
 
     def _run_conventions_checks(self, conanfile="conanfile.py"):
         """ Checks for conventions which we can't automatically update

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -94,8 +94,6 @@ class Command(object):
                            help='Add secrets to all Conan GitHub repositories of an organisation.'
                                 'Set env vars CONAN_LOGIN_USERNAME and CONAN_PASSSWORD and argument --remote-token')
         group.add_argument('--local', action='store_true', help='Update current local repository')
-        group.add_argument('-t', '--travisfile', type=str, nargs='?', const='.travis.yml',
-                           help='Travis file to be updated e.g. .travis.yml')
         group.add_argument('-a', '--appveyorfile', type=str, nargs='?', const='appveyor.yml',
                            help='Appveyor file to be updated e.g. appveyor.yml')
         group.add_argument('-azp', '--azpfile', type=str, nargs='?', const='azure-pipelines.yml',
@@ -148,8 +146,6 @@ class Command(object):
                 else:
                     if arguments.conanfile:
                         self._update_conanfile(arguments.conanfile)
-                    if arguments.travisfile:
-                        self._update_compiler_jobs(arguments.travisfile)
                     if arguments.appveyorfile:
                         self._update_appveyor_file(arguments.appveyorfile)
                     if arguments.azpfile:

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -34,7 +34,7 @@ from .actions.update_c_remove_compiler_cppstd import update_c_remove_compiler_cp
 from .actions.update_migrate_travis_to_import_and_gha import update_migrate_travis_to_import_and_gha
 from .actions.update_travis_import_to_fixed_commit import update_travis_import_to_fixed_commit
 
-__version__ = '1.0.0-alpha'
+__version__ = '1.0.0'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -34,7 +34,7 @@ from .actions.update_c_remove_compiler_cppstd import update_c_remove_compiler_cp
 from .actions.update_migrate_travis_to_import_and_gha import update_migrate_travis_to_import_and_gha
 from .actions.update_travis_import_to_fixed_commit import update_travis_import_to_fixed_commit
 
-__version__ = '0.31.0'
+__version__ = '1.0.0-alpha'
 __author__ = 'Bincrafters <bincrafters@gmail.com>'
 __license__ = 'MIT'
 

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -59,8 +59,8 @@ compiler_versions_deletion = {'visual': ('12', '14')}
 openssl_version_matrix = {'1.0.1': {'latest_patch': 'h', 'eol': True},
                           '1.0.2': {'latest_patch': 'u', 'eol': True},
                           '1.1.0': {'latest_patch': 'l', 'eol': True},
-                          '1.1.1': {'latest_patch': 'm', 'eol': False},
-                          '3.0.': {'latest_patch': '1', 'eol': False},
+                          '1.1.1': {'latest_patch': 'n', 'eol': False},
+                          '3.0.': {'latest_patch': '2', 'eol': False},
                           }
 
 @contextlib.contextmanager

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -31,7 +31,6 @@ from .actions.update_c_delete_meta_lines import update_c_delete_meta_lines
 from .actions.update_c_tools_version import update_c_tools_version
 from .actions.update_c_recipe_references import update_c_recipe_references
 from .actions.update_c_remove_compiler_cppstd import update_c_remove_compiler_cppstd
-from .actions.update_readme_travis_url import update_readme_travis_url
 from .actions.update_migrate_travis_to_import_and_gha import update_migrate_travis_to_import_and_gha
 from .actions.update_travis_import_to_fixed_commit import update_travis_import_to_fixed_commit
 
@@ -363,9 +362,7 @@ class Command(object):
         if not os.path.isfile(readme):
             return [False, ]
 
-        return [
-            update_readme_travis_url(self, readme)
-        ]
+        return [True, ]
 
     def _run_conventions_checks(self, conanfile="conanfile.py"):
         """ Checks for conventions which we can't automatically update

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -90,9 +90,6 @@ class Command(object):
         parser = argparse.ArgumentParser(description="Bincrafters Conventions {}".format(__version__))
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--remote', type=str, help='Github repo to be updated e.g. bincrafters/conan-foobar')
-        group.add_argument('--remote-add-gha-secrets', type=str,
-                           help='Add secrets to all Conan GitHub repositories of an organisation.'
-                                'Set env vars CONAN_LOGIN_USERNAME and CONAN_PASSSWORD and argument --remote-token')
         group.add_argument('--local', action='store_true', help='Update current local repository')
         group.add_argument('-a', '--appveyorfile', type=str, nargs='?', const='appveyor.yml',
                            help='Appveyor file to be updated e.g. appveyor.yml')
@@ -138,8 +135,6 @@ class Command(object):
                 self._update_remote(arguments.remote, arguments.conanfile, arguments.dry_run, arguments.project_pattern,
                                     arguments.branch_pattern, arguments.all_branches, arguments.remote_token,
                                     arguments.remote_max_repos)
-            elif arguments.remote_add_gha_secrets:
-                self._add_gha_secrets_to_github_repos(user=arguments.remote_add_gha_secrets, token=arguments.remote_token)
             else:
                 if arguments.check:
                     self._run_conventions_checks()
@@ -403,58 +398,6 @@ class Command(object):
         repo = git.Repo.clone_from(github_url, project_path)
         self.output_remote_update("Clone project {} to {}".format(github_url, project_path))
         return repo, project_path
-
-    # Method is from https://developer.github.com/v3/actions/secrets/#example-encrypting-a-secret-using-python
-    def _encrypt_for_github_actions(self, public_key: str, secret_value: str) -> str:
-        from base64 import b64encode
-        from nacl import encoding, public
-        """Encrypt a Unicode string using the public key."""
-        public_key = public.PublicKey(public_key.encode("utf-8"), encoding.Base64Encoder())
-        sealed_box = public.SealedBox(public_key)
-        encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
-        return b64encode(encrypted).decode("utf-8")
-
-    def _add_gha_secrets_to_github_repos(self, user, token):
-        self.output_remote_update("")
-        self.output_remote_update("Adding/Updating GitHub Actions secret to all Conan repositories for {}".format(user))
-        self.output_remote_update("")
-
-        conan_login_username = os.getenv("CONAN_LOGIN_USERNAME", "bincrafters-user")
-        conan_password = os.getenv("CONAN_PASSWORD", None)
-
-        projects = self._list_user_projects(user, token)
-        credentials = token.split(":", 1)
-        auth = (credentials[0], credentials[1])
-
-        for project in projects:
-            key_request = requests.get("https://api.github.com/repos/{}/actions/secrets/public-key".format(project),
-                                      auth=auth)
-            public_key = key_request.json()
-
-            login_user = self._encrypt_for_github_actions(public_key["key"], conan_login_username)
-            login_password = self._encrypt_for_github_actions(public_key["key"], conan_password)
-
-            url_user = "https://api.github.com/repos/{}/actions/secrets/{}".format(project, "CONAN_LOGIN_USERNAME")
-            url_password = "https://api.github.com/repos/{}/actions/secrets/{}".format(project, "CONAN_PASSWORD")
-
-            data_user = {"key_id": public_key["key_id"], "encrypted_value": login_user}
-            data_pw = {"key_id": public_key["key_id"], "encrypted_value": login_password}
-
-            ru = requests.put(url_user, auth=auth, json=data_user)
-            rp = requests.put(url_password, auth=auth, json=data_pw)
-
-            if ru.status_code == 201 and rp.status_code == 201:
-                self.output_result_check(passed=True,
-                                         title="Adding GitHub Actions Secret for {}".format(project),
-                                         reason="Success")
-            elif ru.status_code == 204 and rp.status_code == 204:
-                self.output_result_check(passed=True,
-                                         title="Updating GitHub Actions Secret for {}".format(project),
-                                         reason="Success")
-            else:
-                self.output_result_check(passed=False,
-                                         title="Adding/Updating GitHub Actions Secret for {}".format(project),
-                                         reason="Failed with {}/{}".format(ru.status_code, rp.status_code))
 
     def _list_user_projects(self, user, token):
         """ List all projects from GitHub public account

--- a/bincrafters_conventions/bincrafters_conventions.py
+++ b/bincrafters_conventions/bincrafters_conventions.py
@@ -87,7 +87,7 @@ class Command(object):
 
         :param args: User arguments
         """
-        parser = argparse.ArgumentParser(description="Bincrafters Conventions")
+        parser = argparse.ArgumentParser(description="Bincrafters Conventions {}".format(__version__))
         group = parser.add_mutually_exclusive_group()
         group.add_argument('--remote', type=str, help='Github repo to be updated e.g. bincrafters/conan-foobar')
         group.add_argument('--remote-add-gha-secrets', type=str,

--- a/bincrafters_conventions/requirements.txt
+++ b/bincrafters_conventions/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.22.0
 GitPython>=3.0.4
-conan>=1.28.0
+conan>=1.53.0

--- a/bincrafters_conventions/requirements.txt
+++ b/bincrafters_conventions/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.22.0
 GitPython>=3.0.4
-conan>=1.18.0
+conan>=1.28.0

--- a/bincrafters_conventions/requirements.txt
+++ b/bincrafters_conventions/requirements.txt
@@ -1,4 +1,3 @@
 requests>=2.22.0
 GitPython>=3.0.4
 conan>=1.18.0
-PyNaCl~=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
 
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Build Tools',
         'License :: OSI Approved :: MIT License',
@@ -78,7 +78,7 @@ setup(
 
     # What does your project relate to?
     keywords=['conan', 'C/C++', 'package', 'libraries', 'developer', 'manager',
-              'dependency', 'tool', 'c', 'c++', 'cpp'],
+              'dependency', 'tool', 'c', 'c++', 'cpp', 'convention', 'updates'],
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
@@ -111,7 +111,7 @@ setup(
 
     # Although 'package_data' is the preferred approach, in some case you may
     # need to place data files outside of your packages. See:
-    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # https://docs.python.org/3.10/distutils/setupscript.html#installing-additional-files # noqa
     # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
     # data_files=[('my_data', ['data/data_file'])],
 

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ setup(
     entry_points={
         'console_scripts': [
             'bincrafters-conventions=bincrafters_conventions.main:run',
+            'bcon=bincrafters_conventions.main:run',
         ],
     },
 )

--- a/tests/files/conan_2_expected.py
+++ b/tests/files/conan_2_expected.py
@@ -32,7 +32,7 @@ class GrpcConan(ConanFile):
     _build_subfolder = "build_subfolder"
 
     requires = (
-        "zlib/1.2.12",
+        "zlib/1.2.13",
         "openssl/1.0.2u",
         "protobuf/3.9.1",
         "c-ares/1.15.0"

--- a/tests/files/conan_2_expected.py
+++ b/tests/files/conan_2_expected.py
@@ -32,7 +32,7 @@ class GrpcConan(ConanFile):
     _build_subfolder = "build_subfolder"
 
     requires = (
-        "zlib/1.2.11",
+        "zlib/1.2.12",
         "openssl/1.0.2u",
         "protobuf/3.9.1",
         "c-ares/1.15.0"

--- a/tests/files/gha_1_expected.yml
+++ b/tests/files/gha_1_expected.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           MATRIX=$(bincrafters-package-tools generate-ci-jobs --platform gha)
           echo "${MATRIX}"
-          echo "::set-output name=matrix::${MATRIX}"
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
   conan:
     needs: generate-matrix
     runs-on: ${{ matrix.config.os }}

--- a/tests/files/gha_1_expected.yml
+++ b/tests/files/gha_1_expected.yml
@@ -3,7 +3,7 @@ env:
 
 on: [push, pull_request]
 
-# bincrafters-conventions:gha-workflow-version:13
+# bincrafters-conventions:gha-workflow-version:14
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install Package Tools
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Install Conan

--- a/tests/files/gha_1_expected.yml
+++ b/tests/files/gha_1_expected.yml
@@ -1,16 +1,16 @@
 env:
-  splitByBuildTypes: "true"
+  BPT_MATRIX_SPLIT_BY_BUILD_TYPES: "true"
 
 on: [push, pull_request]
 
-# bincrafters-conventions:gha-workflow-version:10
+# bincrafters-conventions:gha-workflow-version:13
 # You can add custom environment variables above the version tag
 # Do not modify the tag or anything below the tag
 # This script gets automatically updated
 #
 # Possible configurations:
 # env:
-#   splitByBuildTypes: "false"  # Possible values "false", "true", default: false
+#   BPT_MATRIX_SPLIT_BY_BUILD_TYPES: "false"  # Possible values "false", "true", default: false
 #
 # You can furthermore set any environment variable understood by Conan and Conan Package Tools
 #
@@ -25,11 +25,13 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      BPT_CONFIG_FILE_VERSION: "12"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
       - name: Install Package Tools
@@ -38,8 +40,6 @@ jobs:
           conan user
       - name: Generate Job Matrix
         id: set-matrix
-        env:
-          splitByBuildTypes: ${{ env.splitByBuildTypes }}
         run: |
           MATRIX=$(bincrafters-package-tools generate-ci-jobs --platform gha)
           echo "${MATRIX}"
@@ -51,11 +51,13 @@ jobs:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
     name: ${{ matrix.config.name }}
+    env:
+      BPT_CONFIG_FILE_VERSION: "12"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v3
         with:
           python-version: "3.8"
       - name: Install Conan
@@ -73,3 +75,11 @@ jobs:
           CONAN_PASSWORD: ${{ secrets.CONAN_PASSWORD }}
         run: |
           bincrafters-package-tools --auto
+  finished:
+    needs: conan
+    runs-on: ubuntu-20.04
+    name: "All GitHub Actions Jobs Finished"
+    steps:
+      - name: Finish
+        run: |
+          echo "All GitHub Actions jobs finished"

--- a/tests/files/gha_1_old.yml
+++ b/tests/files/gha_1_old.yml
@@ -1,5 +1,5 @@
 env:
-  splitByBuildTypes: "true"
+  BPT_MATRIX_SPLIT_BY_BUILD_TYPES: "true"
 
 # bincrafters-conventions:gha-workflow-version:0
 

--- a/tests/test_update_file.py
+++ b/tests/test_update_file.py
@@ -1,25 +1,33 @@
 #!/usr/bin/env python
 
-from bincrafters_conventions.bincrafters_conventions import Command
+from bincrafters_conventions.bincrafters_conventions import chdir, main
 
 import tempfile
+import os
 from shutil import copyfile
 
 
-def _prepare_old_file(file_name: str, suffix: str, old = "", expected=""):
+def _prepare_old_file(file_name: str, suffix: str, file_target_name: str = "", old: str = "", expected: str = ""):
     if old == "":
         old = file_name + "_old"
 
     if expected == "":
         expected = file_name + "_expected"
 
-    _, path_old = tempfile.mkstemp(prefix=old, suffix=suffix)
-    copyfile("files/{}{}".format(old, suffix), path_old)
+    if file_target_name == "":
+        file_target_name = old
 
-    _, expected_path = tempfile.mkstemp(prefix=expected, suffix=suffix)
-    copyfile("files/{}{}".format(expected, suffix), expected_path)
+    tmp_dir = tempfile.mkdtemp(prefix=old) # , suffix=suffix
 
-    return path_old, expected_path
+    test_file_src = os.path.join("files", "{}{}".format(old, suffix))
+    expected_file_src = os.path.join("files", "{}{}".format(expected, suffix))
+    target_test_file = os.path.join(tmp_dir, "{}{}".format(file_target_name, suffix))
+    target_expected_file = os.path.join(tmp_dir, "{}{}".format(expected, suffix))
+
+    copyfile(test_file_src, target_test_file)
+    copyfile(expected_file_src, target_expected_file)
+
+    return target_test_file, target_expected_file
 
 
 def _compare_file(path_old: str, expected_path: str):
@@ -46,8 +54,7 @@ def test_updated_conanfile():
     path_old, path_expected = _prepare_old_file("conan_1", ".py", old="conan_1_expected")
 
     args = ['--conanfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -59,8 +66,7 @@ def test_conanfile_default_options():
     path_old, path_expected = _prepare_old_file("conan_1", ".py")
 
     args = ['--conanfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -72,8 +78,7 @@ def test_conanfile_default_options_mutiline():
     path_old, path_expected = _prepare_old_file("conan_multiline_options", ".py", expected="conan_1_expected")
 
     args = ['--conanfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -85,8 +90,7 @@ def test_conanfile_2():
     path_old, path_expected = _prepare_old_file("conan_2", ".py")
 
     args = ['--conanfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -98,8 +102,7 @@ def test_appveyor_update_up_to_date():
     path_old, path_expected = _prepare_old_file("appveyor_1", ".yml", old="appveyor_1_expected")
 
     args = ['--appveyorfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -111,8 +114,7 @@ def test_appveyor_update():
     path_old, path_expected = _prepare_old_file("appveyor_1", ".yml")
 
     args = ['--appveyorfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -124,8 +126,7 @@ def test_appveyor_update_new_compiler_jobs():
     path_old, path_expected = _prepare_old_file("appveyor_2", ".yml")
 
     args = ['--appveyorfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -137,8 +138,7 @@ def test_appveyor_3_32bit_builds_update():
     path_old, path_expected = _prepare_old_file("appveyor_3_32bit_builds", ".yml")
 
     args = ['--appveyorfile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -147,51 +147,51 @@ def test_update_travis_file():
     """ Create a standard travis file and update it.
     """
 
-    path_old, path_expected = _prepare_old_file("travis_1", ".yml")
+    path_old, path_expected = _prepare_old_file("travis_1", ".yml", file_target_name=".travis")
 
-    args = ['--travisfile', path_old]
-    command = Command()
-    command.run(args)
+    with chdir(os.path.dirname(path_old)):
+        args = []
+        main(args)
 
     assert _compare_file(path_old, path_expected)
 
 
 def test_update_travis_2_pages():
-    path_old, path_expected = _prepare_old_file("travis_2", ".yml")
+    path_old, path_expected = _prepare_old_file("travis_2", ".yml", file_target_name=".travis")
 
-    args = ['--travisfile', path_old]
-    command = Command()
-    command.run(args)
+    with chdir(os.path.dirname(path_old)):
+        args = []
+        main(args)
 
     assert _compare_file(path_old, path_expected)
 
 
 def test_update_travis_4_pages():
-    path_old, path_expected = _prepare_old_file("travis_3", ".yml")
+    path_old, path_expected = _prepare_old_file("travis_3", ".yml", file_target_name=".travis")
 
-    args = ['--travisfile', path_old]
-    command = Command()
-    command.run(args)
+    with chdir(os.path.dirname(path_old)):
+        args = []
+        main(args)
 
     assert _compare_file(path_old, path_expected)
 
 
 def test_update_travis_import_to_fixed_hash():
-    path_old, path_expected = _prepare_old_file("travis_4", ".yml")
+    path_old, path_expected = _prepare_old_file("travis_4", ".yml", file_target_name=".travis")
 
-    args = ['--travisfile', path_old]
-    command = Command()
-    command.run(args)
+    with chdir(os.path.dirname(path_old)):
+        args = []
+        main(args)
 
     assert _compare_file(path_old, path_expected)
 
 
 def test_update_travis_installer_only_import_to_fixed_hash():
-    path_old, path_expected = _prepare_old_file("travis_5", ".yml")
+    path_old, path_expected = _prepare_old_file("travis_5", ".yml", file_target_name=".travis")
 
-    args = ['--travisfile', path_old]
-    command = Command()
-    command.run(args)
+    with chdir(os.path.dirname(path_old)):
+        args = []
+        main(args)
 
     assert _compare_file(path_old, path_expected)
 
@@ -203,7 +203,6 @@ def test_gha():
     path_old, path_expected = _prepare_old_file("gha_1", ".yml")
 
     args = ['--ghafile', path_old]
-    command = Command()
-    command.run(args)
+    main(args)
 
     assert _compare_file(path_old, path_expected)

--- a/tests/test_update_file.py
+++ b/tests/test_update_file.py
@@ -71,8 +71,8 @@ def test_conanfile_default_options():
     assert _compare_file(path_old, path_expected)
 
 
-def test_conanfile_default_options_mutiline():
-    """ Try to update an conanfile which has old styled multiline default options
+def test_conanfile_default_options_multiline():
+    """ Try to update a conanfile which has old styled multiline default options
     """
 
     path_old, path_expected = _prepare_old_file("conan_multiline_options", ".py", expected="conan_1_expected")
@@ -84,7 +84,7 @@ def test_conanfile_default_options_mutiline():
 
 
 def test_conanfile_2():
-    """ Try to update an conanfile which old Conan recipe references
+    """ Try to update a conanfile which old Conan recipe references
     """
 
     path_old, path_expected = _prepare_old_file("conan_2", ".py")


### PR DESCRIPTION
# Changes v1.0

bincrafters-conventions will start to use semantic versioning more strictly, hence the major version bump because of the following breaking changes

## User-facing

### Breaking
  * Increase the minimum Conan version from 1.18.0 to 1.53.0
    * This allows to start rewriting this tool to be compatible with Conan 1.x AND 2.x 
    * ~~Increase minimum Conan version from 1.18.0 to 1.28.0: This allows us to require the `required_conan_version` attribute as well as other changes between those versions~~
  * Remove `-t` / `--travisfile` CLI argument
    * Travis file updates can still be run by running `bincrafters-conventions` without any arguments to run all updates and checks. In reality, Travis file updates are already not isolated as under most conditions it will try to migrate build jobs to GitHub Actions anyway. 
  * Remove `--remote-add-gha-secrets` CLI argument that adds secrets to all Conan GitHub repositories of an organization
    *  This feature is obsolete as GitHub allows now to specify secrets on the organization level 
  * Remove Convention Update: Remove the Readme Update that changed the Travis URL for the Bincrafters org from `https://travis-ci.org/bincrafters` to `https://travis-ci.com/bincrafters`


### New features

  * Add alias `bcon` for `bincrafters-conventions` for convenience. It's much shorter and faster typed
  * Display version in CLI description
  * Update GHA workflow file
    * This adds a new CI job, that runs after all other jobs are finished successfully. This can be used to e.g. configure GitHub auto-merge feature by requiring this particular job to succeed. This wasn't possible previously as the amount and names of the build jobs are dynamic and change.
    * Updates the version of used GitHub Actions within this workflow file
    * Use `$GITHUB_OUTPUT` instead of `::set-output` (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

 
### Improvements

  * Update to the latest OpenSSL patch level to 1.1.1n and 3.0.2


## Internal
  * Update CI scripts
  

